### PR TITLE
Explicit resolve marker

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 var createProbable = require('probable').createProbable;
 var keyRefRegex = /{(\S+?)}/g;
 
+const needsToBeResolved = Symbol('resolveTarget');
+
 function Tablenest(opts) {
   var probable;
 
@@ -19,30 +21,55 @@ function Tablenest(opts) {
     }
 
     return {
-      roll: roll
+      roll
     };
 
     function roll() {
-      return expatiateToDeath('{root}', ['root']);
+      return expatiateToDeath(tablesForKeys['root'].roll());
     }
 
-    function expatiateToDeath(text, keys) {
-      var expatiated = keys.reduce(expatiateKeyRef, text);
-      var nextKeys = getKeyRefs(expatiated);
-      if (nextKeys.length > 0) {
-        return expatiateToDeath(expatiated, nextKeys);
+    function expatiateToDeath(thing) {
+      debugger;
+      if (thing[needsToBeResolved]) {
+        let type = typeof thing.target;
+        if (type === 'string') {
+          return expatiateString(thing.target);
+        } else if (type === 'object') {
+          return expatiateObject(thing.target);
+        }
       } else {
-        return expatiated;
+        return thing;
       }
     }
 
-    function expatiateKeyRef(text, key) {
-      var expatiated = text;
+    function expatiateString(text) {
+      var keys = getKeyRefs(text);
+      if (keys.length < 1) {
+        // The whole thing, then, is considered a key.
+        return expatiateToDeath(tablesForKeys[text].roll());
+      }
+
+      // If there are keys marked by {} within the string,
+      // we assume the result of this branch is a string,
+      // rather than another type entirely.
+      return expatiateToDeath(keys.reduce(expatiateKeyRefInString, text));
+    }
+
+    function expatiateKeyRefInString(text, key) {
+      var expatiated = text.slice();
       if (key in tablesForKeys) {
         var resolved = tablesForKeys[key].roll();
         expatiated = expatiated.replace('{' + key + '}', resolved);
       }
       return expatiated;
+    }
+
+    function expatiateObject(obj) {
+      var resolvedObj = {};
+      for (var key in obj) {
+        resolvedObj[key] = expatiateToDeath(obj[key]);
+      }
+      return resolvedObj;
     }
   }
 
@@ -60,4 +87,14 @@ function getKeyRefs(text) {
   return refs;
 }
 
-module.exports = Tablenest;
+function markResolvable(target) {
+  return {
+    [needsToBeResolved]: true,
+    target
+  };
+}
+
+module.exports = {
+  Tablenest,
+  r: markResolvable
+};

--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ function Tablenest(opts) {
 
   if (opts) {
     probable = createProbable({
-      random: opts.random
+      random: opts.random,
+      recurse: false
     });
   } else {
     probable = createProbable();
@@ -29,13 +30,15 @@ function Tablenest(opts) {
     }
 
     function expatiateToDeath(thing) {
-      debugger;
       if (thing[needsToBeResolved]) {
         let type = typeof thing.target;
         if (type === 'string') {
           return expatiateString(thing.target);
         } else if (type === 'object') {
+          //if (Array.isArray(thing.target)) {
+          //} else {
           return expatiateObject(thing.target);
+          //}
         }
       } else {
         return thing;
@@ -87,7 +90,14 @@ function getKeyRefs(text) {
   return refs;
 }
 
-function markResolvable(target) {
+function markResolvable(n) {
+  var target = n;
+  // If this function is used as a template tag
+  // the arguments will be wrapped such that we'll
+  // have to pull the contents out.
+  if ('raw' in n) {
+    target = n[0];
+  }
   return {
     [needsToBeResolved]: true,
     target

--- a/package-lock.json
+++ b/package-lock.json
@@ -217,9 +217,9 @@
       "dev": true
     },
     "probable": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/probable/-/probable-2.1.2.tgz",
-      "integrity": "sha512-1qw4a+V+whMEnTcLXDJclB/WhMlIf5eBj8WnQ27S7FL/sk2UhTfbgaXI3hEU/zza6hdmSqUIy9sVsM2pDT18aA=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/probable/-/probable-2.1.3.tgz",
+      "integrity": "sha512-ha/Z/fqBLDyfMefUuN3/xC2zg3KWJ1Ca7GXwl2ttPdr/n9Ay5e+uC1+uOyxFYCmqh+1yaVFnEObJAOC2T9NHaQ=="
     },
     "resolve": {
       "version": "1.10.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
     "tape": "^4.10.1"
   },
   "dependencies": {
-    "probable": "^2.1.2"
+    "probable": "^2.1.3"
   }
 }

--- a/tests/basictests.js
+++ b/tests/basictests.js
@@ -1,22 +1,31 @@
 var test = require('tape');
-var Tablenest = require('../index');
+var { Tablenest, r } = require('../index');
 var seedrandom = require('seedrandom');
 
 var bogGrammar = {
-  root: [[50, '{activeScene}'], [25, '{inactiveScene}']],
+  root: [[50, r`activeScene`], [25, r`inactiveScene`]],
   activeScene: [
-    [10, '{animalScene}'],
-    [5, '{animalScene} {animalScene}'],
+    [
+      40,
+      r({
+        text: r`plants`,
+        subtext: r`naturalEntity`,
+        intensity: r`highNumber`
+      })
+    ],
+    [10, r`animalScene`],
+    [5, r`{animalScene} {animalScene}`],
     [10, 'Bubbles blurble through the mud.']
   ],
   inactiveScene: [
-    [1, '{plants} {locationVerb} {location}.'],
+    [1, r`{plants} {locationVerb} {location}.`],
     [
       1,
-      '{naturalEntity} {naturalEntityAction} {naturalEntityFieldOfInfluence}.'
+      r`{naturalEntity} {naturalEntityAction} {naturalEntityFieldOfInfluence}.`
     ]
   ],
-  animalScene: [[1, 'A {animal} {animalAction} {animalAdverb}.']],
+  highNumber: [[1, 1000], [1, 10000], [2, 99999], [4, 10000000]],
+  animalScene: [[1, r`A {animal} {animalAction} {animalAdverb}.`]],
   plants: [[1, 'Vines'], [3, 'Lily pads'], [2, 'Wilted willows'], [4, 'Reeds']],
   locationVerb: [[1, 'sprawl'], [1, 'rest'], [2, 'lie'], [1, 'sit']],
   location: [

--- a/tests/basictests.js
+++ b/tests/basictests.js
@@ -87,10 +87,10 @@ var bogGrammar = {
 
 var expectedResults = [
   'Reeds rest all around.',
-  'A lizard lies formally. A komodo dragon stretches casually.',
-  'Vines lie all around.',
+  { text: 'Lily pads', subtext: 'Warmth', intensity: 99999 },
   'Bubbles blurble through the mud.',
-  'A muskrat stretches lazily.'
+  'Reeds sit all around.',
+  'A swarm of leeches rises from the muck lazily.'
 ];
 
 var random = seedrandom('test');
@@ -103,7 +103,7 @@ function runTest(expected) {
       random: random
     });
     var bogTable = tablenest(bogGrammar);
-    t.equal(bogTable.roll(), expected, 'Correct result is rolled.');
+    t.deepEqual(bogTable.roll(), expected, 'Correct result is rolled.');
     t.end();
   });
 }


### PR DESCRIPTION
Allow/require user to explicitly mark (with `r`) stuff that should be resolved; the rest is to be taken literally.